### PR TITLE
Update renderer.js

### DIFF
--- a/public/renderer.js
+++ b/public/renderer.js
@@ -180,7 +180,7 @@ function logMapClick(room, x, y) {
   console.log(room, x, y)
 }
 
-function getRoomFromName(room) { return terrain.find(r => r.name === room) }
+function getRoomFromName(room) { return terrain.find(r => r.room === room) }
 
 function getRoomFromXY(x, y) { return terrain.find(r => r.x == x && r.y == y) }
 
@@ -203,7 +203,7 @@ function changeSectorStatus(roomNameInSector, status) {
 function editTerrain(room, x, y, type) {
   const map = ['plain', 'wall', 'swamp']
   type = map.indexOf(type)
-  const r = terrain.find(r => r.name === room)
+  const r = terrain.find(r => r.room === room)
   const ind = x + (y * 50)
   const part1 = r.terrain.slice(0, ind)
   const part2 = r.terrain.slice(ind + 1)


### PR DESCRIPTION
Terrain no longer puts the room name into the name attribute, but the room attribute.

![image](https://user-images.githubusercontent.com/44329/88699410-4ad05480-d0d5-11ea-9d7d-8fc1473f39a9.png)
