### PR TITLE
Mineral changing, Edit terrain coordinates, and proper room deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ctrl+Left Click to generate a sector
 
 Ctrl+Right Click to remove a sector (fills with solid rooms)*
 
-Middle clicking will flood fill from the cursor's position, 
+Alt+Left Click will flood fill from the cursor's position, 
 this is useful to find isolated rooms
 
 *If a room is removed but not regenerated it will be completely walled off with game objects removed. This is done because map tool can not completely remove a room as this must be done in the CLI with the `map.removeRoom` command.
@@ -32,7 +32,7 @@ Left click sets tile to wall
 
 Right click sets tile to plain
 
-Middle click sets tile to swamp
+Alt+Left click sets tile to swamp
 
 ### Open/Close Rooms
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ If you have a config.yml you can avoid using `.screepsrc` by setting the env var
 
 Left click to generate a room
 
-Right click to remove a room (fills with solid room)*
-
 Ctrl+Left Click to generate a sector
 
-Ctrl+Right Click to remove a sector (fills with solid rooms)*
+Right click to remove a room
 
-Alt+Left Click will flood fill from the cursor's position, 
-this is useful to find isolated rooms
+Alt+Right Click to brick a room
 
-*If a room is removed but not regenerated it will be completely walled off with game objects removed. This is done because map tool can not completely remove a room as this must be done in the CLI with the `map.removeRoom` command.
+Ctrl+Right Click to remove a sector
+
+Alt+Ctrl+Right Click to brick a whole sector
+
+Alt+Left Click will flood fill from the cursor's position, this is useful to find isolated rooms
 
 ### Edit Room Terrain
 

--- a/lib/backend/routes/set.js
+++ b/lib/backend/routes/set.js
@@ -12,7 +12,11 @@ module.exports.POST = async function (req, res) {
       }
     }
   } = req
-  let rooms = req.body
+  let { rooms, clean } = req.body
+  const received = rooms.length
+  const known = new Set((await db['rooms.terrain'].find({}, { _id: false, room: true })).map(r => r.room))
+  const total = known.size
+  clean.forEach(r => known.delete(r))
   let ps = rooms.map(
     async ({
       terrain,
@@ -54,11 +58,15 @@ module.exports.POST = async function (req, res) {
         o.room = room
         return db['rooms.objects'].insert(o)
       })
+      known.delete(room)
       return true
     }
   )
   let ret = await Promise.all(ps)
   await map.updateTerrainData()
+  await Promise.all(
+    [...known.values()].map(r => map.removeRoom(r))
+  )
   pubsub.publish(pubsub.keys.RUNTIME_RESTART, '1')
   return ret
 }

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
 				<select oninput="currentTool = this.value">
 					<option value="gen">Generate Rooms</option>
 					<option value="edit">Edit Room Terrain</option>
+					<option value="mineral">Cycle mineral</option>
 					<option value="access">Open/Close Rooms</option>
 					<option selected value="block">No Tool Selected</option>					
 				</select>

--- a/public/index.js
+++ b/public/index.js
@@ -1,7 +1,5 @@
 self.terrainCache = {}
 
-self.roomsToBrick = []
-
 const server = ``
 const wallChance = 0.25
 function getTerrain (room, remote) {

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -1132,3 +1132,29 @@ async function fixAll() {
   console.log(`All rooms fixed. Run save to apply.`)
   alert(`All rooms fixed. Run save to apply.`)
 }
+
+function getStats(sectorRoom) {
+  const stats = {
+    sources: 0,
+    doubleSource: 0,
+    minerals: { H: 0, O: 0, Z: 0, K: 0, U: 0, L: 0, X: 0, },
+  }
+  const coords = getSectorBounds(sectorRoom, "none")
+  for (let x = coords.start.x; x < coords.end.x; x++) {
+    for (let y = coords.start.y; y < coords.end.y; y++) {
+      const name = utils.roomNameFromXY(x, y)
+      const room = terrain.find(r => r.name === name)
+      if (!room) continue;
+      const sources = room.objects.filter(o => o.type === "source")
+      stats.sources += sources.length ?? 0
+      if (sources.length > 1) {
+        stats.doubleSource += 1
+      }
+      const mineral = room.objects.find(o => o.type === "mineral")
+      stats.minerals[mineral.mineralType] ??= 0
+      stats.minerals[mineral.mineralType]++
+    }
+  }
+  console.log(`sources: ${stats.sources}, double: ${stats.doubleSource}, mineral: ${Object.entries(stats.minerals).map(([m, n]) => `${n} of ${m}`).join(", ")}`)
+  return stats
+}

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -150,7 +150,7 @@ const tools = {
     { key: 'left', action: ({ room }) => gen(room) },
     { key: 'ctrl+left', action: ({ room }) => generateSector(room) },
     {
-      key: 'middle',
+      key: 'alt+left',
       action: ({ e }) => {
         flood = flood ? false : { x: e.clientX, y: e.clientY }
       }
@@ -160,7 +160,7 @@ const tools = {
   ],
   edit: [
     { key: 'left', action: ({ room, x, y }) => editTerrain(room, x, y, 'wall') },
-    { key: 'middle', action: ({ room, x, y }) => editTerrain(room, x, y, 'swamp') },
+    { key: 'alt+left', action: ({ room, x, y }) => editTerrain(room, x, y, 'swamp') },
     { key: 'right', action: ({ room, x, y }) => editTerrain(room, x, y, 'plain') }
   ],
   mineral: [
@@ -175,7 +175,7 @@ const tools = {
   ],
   block: [
     { key: 'left', action: ({ room, x, y }) => logMapClick(room, x, y) },
-    { key: 'middle', action: ({ room, x, y }) => logMapClick(room, x, y) },
+    { key: 'alt+left', action: ({ room, x, y }) => logMapClick(room, x, y) },
     { key: 'right', action: ({ room, x, y }) => logMapClick(room, x, y) }
   ]
 }

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -163,6 +163,10 @@ const tools = {
     { key: 'middle', action: ({ room, x, y }) => editTerrain(room, x, y, 'swamp') },
     { key: 'right', action: ({ room, x, y }) => editTerrain(room, x, y, 'plain') }
   ],
+  mineral: [
+    { key: 'left', action: ({ room }) => cycleMineral(room) },
+    { key: 'right', action: ({ room }) => cycleMineral(room, false) },
+  ],
   access: [
     { key: 'left', action: ({ room }) => changeRoomStatus(getRoomFromName(room), 'normal') },
     { key: 'ctrl+left', action: ({ room }) => changeSectorStatus(room, 'normal') },
@@ -208,6 +212,16 @@ function editTerrain(room, x, y, type) {
   const part1 = r.terrain.slice(0, ind)
   const part2 = r.terrain.slice(ind + 1)
   r.terrain = terrainCache[room].terrain = part1 + type + part2
+  r.remote = false
+}
+
+function cycleMineral(room, forward=true) {
+  const minerals = ['H', 'O', 'Z', 'K', 'U', 'L', 'X'];
+  const r = terrain.find(r => r.room === room);
+  const mineral = r.objects.find(o => o.type === "mineral");
+  if (!mineral) return;
+  const idx = minerals.indexOf(mineral.mineralType);
+  mineral.mineralType = minerals.at(idx + (forward ? 1 : -1));
   r.remote = false
 }
 

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -416,20 +416,23 @@ function renderRoom(ctx, room) {
     ctx.fillRect(rx, ry, 50 * scale, 50 * scale)
     ctx.restore()
   }
-  if (showWalls.checked && room.exits) {
+  if (showWalls.checked) {
+    const exits = getExits(room.room);
     ctx.save()
     ctx.beginPath()
     let x2 = rx + (50 * scale)
     let y2 = ry + (50 * scale)
     ctx.moveTo(rx, ry)
-    ctx[room.exits.top ? 'moveTo' : 'lineTo'](x2, ry)
-    ctx[room.exits.right ? 'moveTo' : 'lineTo'](x2, y2)
-    ctx[room.exits.bottom ? 'moveTo' : 'lineTo'](rx, y2)
-    ctx[room.exits.left ? 'moveTo' : 'lineTo'](rx, ry)
+    const hasExit = (data) => {
+      return typeof data === "boolean" && data || typeof data === "string" && data.split("").some(c => c === "0")
+    }
+    ctx[hasExit(exits.top) ? 'moveTo' : 'lineTo'](x2, ry)
+    ctx[hasExit(exits.right) ? 'moveTo' : 'lineTo'](x2, y2)
+    ctx[hasExit(exits.bottom) ? 'moveTo' : 'lineTo'](rx, y2)
+    ctx[hasExit(exits.left) ? 'moveTo' : 'lineTo'](rx, ry)
     ctx.strokeStyle = 'red'
     ctx.stroke()
     ctx.restore()
-    return
   }
   let mineral = ''
   let colors = {

--- a/public/renderer.js
+++ b/public/renderer.js
@@ -246,8 +246,8 @@ canvas.addEventListener('mouseup', e => {
     if (action) {
       action({
         room,
-        x: mp.rx,
-        y: mp.ry,
+        x: (mp.rx + 50) % 50,
+        y: (mp.ry + 50) % 50,
         e
       })
     }
@@ -376,13 +376,13 @@ function render() {
     ctx.save()
     ctx.translate(vp.x, vp.y)
     ctx.fillStyle = 'rgba(255, 255, 255, 0.5)'
-    let [xo, yo] = [
-      Math.floor(Math.abs(vp.x % scale)),
-      Math.floor(Math.abs(vp.y % scale))
-    ]
 
-    let x = (mp.rx * scale) + (cell.x * scale) // (mp.x + xo)
-    let y = (mp.ry * scale) + (cell.y * scale) // (mp.y + yo)
+    let cellX = cell.x + (cell.x < 0 ? 1 : 0)
+    let cellY = cell.y + (cell.y < 0 ? 1 : 0)
+
+    let x = (mp.rx * scale) + (cellX * 50 * scale)
+    let y = (mp.ry * scale) + (cellY * 50 * scale)
+
     ctx.beginPath()
     ctx.rect(x, y, scale, scale)
     ctx.fill()


### PR DESCRIPTION
This changes the following:
- Adds a new mineral type cycling tool
- Fixed the Edit terrain "brush" to wrap around the center rooms instead of tracking the mouse position. Also fixes some coordinates problems that made room edges very hard to click on in some directions (mostly negative ones)
- Improves on the map-tool <-> server API so that the server can issue the proper room removals for rooms the map-tool has deleted; this makes room bricking unnecessary now, but the feature has been kept
- I personally can't do middle mouse click, so anything that was using those got moved to use Alt-clicking instead