### PR TITLE
Set type to "terrain" when inserting terrain data

### DIFF
--- a/lib/backend/routes/set.js
+++ b/lib/backend/routes/set.js
@@ -49,7 +49,7 @@ module.exports.POST = async function (req, res) {
       )
       await db['rooms.terrain'].update(
         { room },
-        { $set: { terrain } },
+        { $set: { terrain, type: "terrain" } },
         { upsert: true }
       )
       await map.updateRoomImageAssets(room)


### PR DESCRIPTION
Ref: https://github.com/screeps/backend-local/pull/30

If the type isn't set, that decoding check in `api/game/room-terrain` ends up sending back encoded terrain data in all cases, which breaks the API when the `encoded` parameter isn't specified.